### PR TITLE
Fixing bugs when working in the Linux background.

### DIFF
--- a/DuckDNS/Program.cs
+++ b/DuckDNS/Program.cs
@@ -5,58 +5,73 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace DuckDNS
 {
     class Program
     {
-        public static int configVersion = 1; 
+        public static int configVersion = 1;
         public static Settings set = new Settings(); //Used all over the place, so it made sense to only have 1.
         static void Main(string[] args)
         {
-            
             if (File.Exists("duckdns_config.json") == false)
             {
                 CreateConfig();
-            } else
+            }
+            else
             {
                 set = JsonConvert.DeserializeObject<Settings>(File.ReadAllText("duckdns_config.json"));
-                if(set.configfileVersion < configVersion)
+                if (set.configfileVersion < configVersion)
                 {
                     Console.WriteLine("Updating Config File, Please Edit to see what changed.");
                     File.WriteAllText("duckdns_config.json", JsonConvert.SerializeObject(set, Formatting.Indented));
                 }
-                else if(set.configfileVersion > configVersion)
+                else if (set.configfileVersion > configVersion)
                 {
                     Console.WriteLine("Using a config file from a future version of this application is not supported. If issues happen, this is likely your issue.");
                 }
                 Console.WriteLine("Config File Loaded. Sites being Managed:");
-                foreach(var p in set.sites)
+                foreach (var p in set.sites)
                 {
                     Console.WriteLine(p.Domain);
                 }
             }
             Console.WriteLine("Scheduling Automatic Updates every " + set.DoUpdateEveryXMinutes + " Minutes.");
 
-            var tmr = new Timer(TimedUpdate, null, 0, set.DoUpdateEveryXMinutes * 1000 * 60); //Update the DNS names every 5 minutes. Minutes*1000=Minutes in Milliseconds. Runs Immediatly.
-            
-            Console.WriteLine("Console Ready. type \"help\" for help");
-            do
+            TimedUpdate(set.DoUpdateEveryXMinutes * 1000 * 60); //Update the DNS names every 5 minutes. Minutes*1000=Minutes in Milliseconds. Runs Immediatly.
+
+            if (set.IsUseConsoleInput)
             {
-                var command = Console.ReadLine();
-                command = command.ToLower();
-                if(command == "help") { PrintHelp(); }
-                if(command == "ip") { PrintIPAsync(); }
-                if(command == "update") { ForceUpdate(); }
-                if(command == "exit") { Environment.Exit(0); }
-            } while (true);
+                Console.WriteLine("Console Ready. type \"help\" for help");
+                do
+                {
+                    var command = Console.ReadLine();
+                    command = command.ToLower();
+                    if (command == "help") { PrintHelp(); }
+                    if (command == "ip") { PrintIPAsync(); }
+                    if (command == "update") { ForceUpdate(); }
+                    if (command == "exit") { Environment.Exit(0); }
+                } while (true);
+            }
+            else
+            {
+                Console.WriteLine("Console is disabled. (Just update by Schedule)");
+                while (true)
+                {
+                    Thread.Sleep(Timeout.Infinite);
+                }
+            }
         }
 
-        private static void TimedUpdate(object dummy)
+        private static async void TimedUpdate(int millisecondsDelay)
         {
-            Console.WriteLine("Executing Automatic IP Update...");
-            ForceUpdate();
-            return;
+            while (true)
+            {
+                Console.WriteLine("Executing Automatic IP Update...");
+                ForceUpdate();
+                await Task.Delay(millisecondsDelay);
+            }
         }
 
         static void PrintHelp()
@@ -75,10 +90,11 @@ namespace DuckDNS
                 httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("DuckDNS_Updater", "1.0"));
                 var result = await httpClient.GetStringAsync("http://whatismyip.akamai.com/");
                 Console.WriteLine(result);
-            } catch
+            }
+            catch
             {
                 Console.WriteLine("Failed to get IP");
-            } 
+            }
         }
 
         static async void ForceUpdate()
@@ -102,11 +118,12 @@ namespace DuckDNS
                         query += "&ipv6=" + p.force_ipv6_number;
                     }
 
-                    var result = await httpClient.GetStringAsync(query); 
-                    if(result == "KO")
+                    var result = await httpClient.GetStringAsync(query);
+                    if (result == "KO")
                     {
                         Console.WriteLine("Failed to update IP of " + p.Domain);
-                    } else if (result == "OK")
+                    }
+                    else if (result == "OK")
                     {
                         Console.WriteLine("Updated " + p.Domain); //It didn't error, and it didn't return KO, so we are going to assume it worked. Probably not the smartest way.
                     }
@@ -150,6 +167,7 @@ namespace DuckDNS
             public string Message2 = "This config file is reloaded every time the program updates the addresses, so live editing is possible. This can be used to maintain the IP addresses of remote computers.";
             public string Message3 = "At the time of writing, DuckDNS is unable to automatically determine IPv6 addresses, and so unless you override the value, your domain will be ipv4 only.";
             public int DoUpdateEveryXMinutes = 5; //Defauts to every 5 minutes.
+            public bool IsUseConsoleInput = true; // Use runtime console input.
             public int configfileVersion = configVersion; //Useful for future updates.
             public List<ValueSet> sites; //Domain, Token
         }


### PR DESCRIPTION
Add console deactivation option and change timer to asynchronous method.

Fixing a problem in which a stream read error occurs in Console.ReadLine() when running as a background operation on Linux.

I'm making and using Linux services. However, this error occurred and the PR was opened. :)

```
Config File Loaded. Sites being Managed:
<MyDomainName>
Scheduling Automatic Updates every 5 Minutes.
Console Ready. type "help" for help
Executing Automatic IP Update...
Unhandled exception. Reloading Config...
Reload Complete!
System.UnauthorizedAccessException: Access to the path is denied.
 ---> System.IO.IOException: Bad file descriptor
   --- End of inner exception stack trace ---
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
   at Interop.CheckIo(Int64 result, String path, Boolean isDirectory, Func`2 errorRewriter)
   at System.ConsolePal.Read(SafeFileHandle fd, Byte[] buffer, Int32 offset, Int32 count)
   at System.ConsolePal.UnixConsoleStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.StreamReader.ReadBuffer()
   at System.IO.StreamReader.ReadLine()
   at System.IO.SyncTextReader.ReadLine()
   at System.Console.ReadLine()
   at DuckDNS.Program.Main(String[] args)
```